### PR TITLE
Tweak parallel processing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ workflows:
     triggers:
       - schedule:
           # this should be in the middle of the night for most everybody in the US
-          cron: "45 8 * * *"
+          cron: "45 2 * * *"
           filters:
             branches:
               only:

--- a/getdomains.sh
+++ b/getdomains.sh
@@ -5,7 +5,7 @@
 #
 
 # This is how many domains to scan in a single task
-BATCHSIZE="${BATCHSIZE:-1000}"
+BATCHSIZE="${BATCHSIZE:-2500}"
 
 BINDIR=$(dirname "$0")
 


### PR DESCRIPTION
Tweak number of concurrent domains + scan start time, to get complete sub-domain lists complete by EDT morning.