### PR TITLE
Omit today from dates list endpoint

### DIFF
--- a/getdomains.sh
+++ b/getdomains.sh
@@ -32,7 +32,7 @@ else
 	# they will be merged in so there are no duplicates and metadata from
 	# the first instance of the domain will be preserved.
 
-	wget -O "$BINDIR/domains/other-websites.csv" https://raw.githubusercontent.com/GSA/data/master/dotgov-websites/other-websites.csv
+	#wget -O "$BINDIR/domains/other-websites.csv" https://raw.githubusercontent.com/GSA/data/master/dotgov-websites/other-websites.csv
 	wget -O "$BINDIR/domains/0pulse.csv" https://pulse.cio.gov/data/hosts/https.csv
 
 	for i in $BINDIR/domains/*.csv ; do

--- a/scanner_ui/api/tests.py
+++ b/scanner_ui/api/tests.py
@@ -9,23 +9,26 @@ from rest_framework.test import APIClient
 
 @override_settings(API_OMIT_TODAY=False)
 class CheckAPI(SimpleTestCase):
-    client = APIClient()
-    domainsresponse = client.get("/api/v1/domains/")
-    domainsjsondata = json.loads(domainsresponse.content)
-    scansresponse = client.get("/api/v1/scans/")
-    scansjsondata = json.loads(scansresponse.content)
-    datesresponse = client.get("/api/v1/lists/dates/")
-    datesjsondata = json.loads(datesresponse.content)
-    numscans = 9
-    numdomains = 7
-    domains = [
-        '18f.gov',
-        'gsa.gov',
-        'afrh.gov',
-        'cloud.gov',
-        'login.gov',
-        'calendar.gsa.gov',
-        '*.ecmapps.treasuryecm.gov'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.client = APIClient()
+        cls.domainsresponse = cls.client.get("/api/v1/domains/")
+        cls.domainsjsondata = json.loads(cls.domainsresponse.content)
+        cls.scansresponse = cls.client.get("/api/v1/scans/")
+        cls.scansjsondata = json.loads(cls.scansresponse.content)
+        cls.datesresponse = cls.client.get("/api/v1/lists/dates/")
+        cls.datesjsondata = json.loads(cls.datesresponse.content)
+        cls.numscans = 9
+        cls.numdomains = 7
+        cls.domains = [
+            '18f.gov',
+            'gsa.gov',
+            'afrh.gov',
+            'cloud.gov',
+            'login.gov',
+            'calendar.gsa.gov',
+            '*.ecmapps.treasuryecm.gov'
     ]
 
     def test_all_domains(self):

--- a/scanner_ui/api/tests.py
+++ b/scanner_ui/api/tests.py
@@ -10,18 +10,17 @@ from rest_framework.test import APIClient
 @override_settings(API_OMIT_TODAY=False)
 class CheckAPI(SimpleTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.client = APIClient()
-        cls.domainsresponse = cls.client.get("/api/v1/domains/")
-        cls.domainsjsondata = json.loads(cls.domainsresponse.content)
-        cls.scansresponse = cls.client.get("/api/v1/scans/")
-        cls.scansjsondata = json.loads(cls.scansresponse.content)
-        cls.datesresponse = cls.client.get("/api/v1/lists/dates/")
-        cls.datesjsondata = json.loads(cls.datesresponse.content)
-        cls.numscans = 9
-        cls.numdomains = 7
-        cls.domains = [
+    def setUp(self):
+        self.client = APIClient()
+        self.domainsresponse = self.client.get("/api/v1/domains/")
+        self.domainsjsondata = json.loads(self.domainsresponse.content)
+        self.scansresponse = self.client.get("/api/v1/scans/")
+        self.scansjsondata = json.loads(self.scansresponse.content)
+        self.datesresponse = self.client.get("/api/v1/lists/dates/")
+        self.datesjsondata = json.loads(self.datesresponse.content)
+        self.numscans = 9
+        self.numdomains = 7
+        self.domains = [
             '18f.gov',
             'gsa.gov',
             'afrh.gov',

--- a/scanner_ui/api/tests.py
+++ b/scanner_ui/api/tests.py
@@ -1,13 +1,13 @@
-from django.test import SimpleTestCase
-from rest_framework.test import APIClient
-import json
-import datetime
 import csv
+import datetime
+import json
 import io
 
-# tests for views
+from django.test import override_settings, SimpleTestCase
+from rest_framework.test import APIClient
 
 
+@override_settings(API_OMIT_TODAY=False)
 class CheckAPI(SimpleTestCase):
     client = APIClient()
     domainsresponse = client.get("/api/v1/domains/")

--- a/scanner_ui/api/views.py
+++ b/scanner_ui/api/views.py
@@ -46,7 +46,7 @@ class ItemsWrapper(OrderedDict):
 # for the scan using it.
 def get_scans_from_ES(*, scantype=None, domain=None, request=None, excludeparams=None, date=None, raw=False):
     es = Elasticsearch([os.environ['ESURL']])
-    dates = get_dates()
+    dates = get_dates(omit_today=True)
 
     if date is None or date not in dates:
         date = dates[1]
@@ -104,7 +104,7 @@ def get_scans_from_ES(*, scantype=None, domain=None, request=None, excludeparams
 # get the list of scantypes by scraping the indexes
 def get_scan_types(date=None):
     es = Elasticsearch([os.environ['ESURL']])
-    dates = get_dates()
+    dates = get_dates(omit_today=True)
     if date is None:
         date = dates[1]
     selectedindex = date + '-*'
@@ -296,7 +296,7 @@ def retrieve_csv(request, scantype=None, date=None):
 def uniquevalues(date=None, scantype=None, field=None, subfield=None):
     if date is None:
         # default to most recent date
-        date = get_dates()[1]
+        date = get_dates(omit_today=True)[1]
 
     if scantype is None:
         raise Exception('no scantype specified')
@@ -310,7 +310,7 @@ class ListsViewset(viewsets.GenericViewSet):
     queryset = ''
 
     def dates(self, request):
-        dates = get_dates()[1:]
+        dates = get_dates(omit_today=True)[1:]
         return Response(dates)
 
     def agencies(self, request, scantype=None, date=None):

--- a/scanner_ui/api/views.py
+++ b/scanner_ui/api/views.py
@@ -46,7 +46,7 @@ class ItemsWrapper(OrderedDict):
 # for the scan using it.
 def get_scans_from_ES(*, scantype=None, domain=None, request=None, excludeparams=None, date=None, raw=False):
     es = Elasticsearch([os.environ['ESURL']])
-    dates = get_dates(omit_today=True)
+    dates = get_dates()
 
     if date is None or date not in dates:
         date = dates[1]
@@ -104,7 +104,7 @@ def get_scans_from_ES(*, scantype=None, domain=None, request=None, excludeparams
 # get the list of scantypes by scraping the indexes
 def get_scan_types(date=None):
     es = Elasticsearch([os.environ['ESURL']])
-    dates = get_dates(omit_today=True)
+    dates = get_dates()
     if date is None:
         date = dates[1]
     selectedindex = date + '-*'
@@ -296,7 +296,7 @@ def retrieve_csv(request, scantype=None, date=None):
 def uniquevalues(date=None, scantype=None, field=None, subfield=None):
     if date is None:
         # default to most recent date
-        date = get_dates(omit_today=True)[1]
+        date = get_dates()[1]
 
     if scantype is None:
         raise Exception('no scantype specified')
@@ -310,7 +310,7 @@ class ListsViewset(viewsets.GenericViewSet):
     queryset = ''
 
     def dates(self, request):
-        dates = get_dates(omit_today=True)[1:]
+        dates = get_dates()[1:]
         return Response(dates)
 
     def agencies(self, request, scantype=None, date=None):

--- a/scanner_ui/settings.py
+++ b/scanner_ui/settings.py
@@ -173,3 +173,7 @@ else:
     servicejson = os.environ['VCAP_SERVICES']
     services = json.loads(servicejson)
     os.environ['ESURL'] = services['elasticsearch56'][0]['credentials']['uri']
+
+# By default, don't return today's scan results via the API.
+# We do this to avoid in-progress scans from appearing in the UI.
+API_OMIT_TODAY = True

--- a/scanner_ui/ui/tests.py
+++ b/scanner_ui/ui/tests.py
@@ -1,14 +1,14 @@
-from django.test import SimpleTestCase
-from django.test import Client
 import csv
-import re
 import json
+import re
+
+from django.test import override_settings, Client, SimpleTestCase
+
 from .viewfunctions import get_dates, getquery, get_list_from_fields, deperiodize, periodize, deslash, domainsWith, mixpagedatain, popupbuilder
 
-# Create your tests here.
 
-
-class checkviewfunctions(SimpleTestCase):
+@override_settings(API_OMIT_TODAY=False)
+class CheckViewFunctions(SimpleTestCase):
     def test_get_dates(self):
         dates = get_dates()
         self.assertEqual(len(dates), 2)
@@ -92,6 +92,7 @@ class checkviewfunctions(SimpleTestCase):
         self.assertEqual(popup, p)
 
 
+@override_settings(API_OMIT_TODAY=False)
 class CheckUI(SimpleTestCase):
     client = Client()
 

--- a/scanner_ui/ui/viewfunctions.py
+++ b/scanner_ui/ui/viewfunctions.py
@@ -3,6 +3,7 @@ import os
 import re
 from datetime import datetime
 
+from django.conf import settings
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.query import Range, Bool, Q
@@ -97,7 +98,7 @@ def getquery(index, present=None, agency=None, domaintype=None, query=None, org=
 
 
 # search in ES for the list of dates that are indexed
-def get_dates(omit_today=False):
+def get_dates():
     es = Elasticsearch([os.environ['ESURL']])
     indexlist = es.indices.get_alias().keys()
     datemap = {}
@@ -113,7 +114,7 @@ def get_dates(omit_today=False):
     # The use case for this is to omit potentially on-going, incomplete scans
     # dates from the frontend.
     # TODO: Revisit this logic, or the default behavior of the API.
-    if omit_today:
+    if settings.API_OMIT_TODAY:
         today = datetime.utcnow().date().isoformat()
         dates = [
             date


### PR DESCRIPTION
* For a 26k domain list, scan all in one set of parallel chunks.
* Remove the current calendar date from the date list endpoint, so the UI will omit incomplete scans