### PR TITLE
Tweaks for the production cloud.gov space

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,37 +90,7 @@ jobs:
             cf auth "$CF_USERNAME" "$CF_PASSWORD"
             cf target -o "$CF_ORG" -s "$CF_SPACE"
 
-            # get the list of URLs and split it up
-            pip3 install -r requirements.txt
-            TMPDIR="${TMPDIR:-/tmp}"
-            ./getdomains.sh "$TMPDIR/splitdir"
-
-            # this tells cloud.gov to run the scan
-            # XXX This is assuming that the output of getdomains won't change
-            # XXX too much between when we run it here and when it runs on the
-            # XXX task nodes.  Probably a safe assumption, but there might be
-            # XXX a better way to do this.
-            for i in $(ls "$TMPDIR/splitdir") ; do
-              cf run-task scanner-ui "/app/scan_engine.sh $i" --name "scan_engine $i" -m 1024M -k 4096M
-              if [ "$?" != "0" ] ; then
-                echo "running task on $i failed to work, pausing until previous jobs complete"
-                NUMSCANS="$(cf tasks scanner-ui | grep RUNNING | wc -l)"
-                until [ "$(cf tasks scanner-ui | grep RUNNING | wc -l)" != "$NUMSCANS" ] ; do
-                  echo "waiting until there's room to run $i"
-                  sleep 600
-                done
-                cf run-task scanner-ui "/app/scan_engine.sh $i" --name "scan_engine $i" -m 1024M -k 4096M
-                if [ "$?" != "0" ] ; then
-                  FAILED="$i $FAILED"
-                  echo "$i task failed twice:  maybe we are out of memory?  Investigate!"
-                  echo "    trying the next task..."
-                fi
-              fi
-            done
-            if [ -n "$FAILED" ] ; then
-              echo "summary of tasks that failed:  $FAILED"
-              exit 1
-            fi
+            ./spawn_scans.sh
 
 workflows:
   version: 2

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python3 manage.py collectstatic --noinput ; gunicorn -t 300 -b :$PORT scanner_ui.wsgi
+web: python3 manage.py collectstatic --noinput ; gunicorn -t 600 -b :$PORT scanner_ui.wsgi

--- a/getdomains.sh
+++ b/getdomains.sh
@@ -5,7 +5,7 @@
 #
 
 # This is how many domains to scan in a single task
-BATCHSIZE="${BATCHSIZE:-2500}"
+BATCHSIZE="${BATCHSIZE:-3000}"
 
 BINDIR=$(dirname "$0")
 

--- a/getdomains.sh
+++ b/getdomains.sh
@@ -5,7 +5,7 @@
 #
 
 # This is how many domains to scan in a single task
-BATCHSIZE="${BATCHSIZE:-3000}"
+BATCHSIZE="${BATCHSIZE:-2500}"
 
 BINDIR=$(dirname "$0")
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,6 @@ applications:
   memory: 256M
   instances: 1
   random-route: true
-  command: python3 manage.py collectstatic --noinput ; gunicorn -t 300 -b :8080 scanner_ui.wsgi
+  command: python3 manage.py collectstatic --noinput ; gunicorn -t 600 -b :8080 scanner_ui.wsgi
   env:
     DISABLE_COLLECTSTATIC: 1

--- a/spawn_scans.sh
+++ b/spawn_scans.sh
@@ -7,6 +7,12 @@
 TMPDIR="${TMPDIR:-/tmp}"
 ./getdomains.sh "$TMPDIR/splitdir"
 
+# Kill any on-going scans
+cf tasks scanner-ui | grep RUNNING | sed 's/|/ /' | awk '{print $1}' | while read line ; do
+  echo "Terminating running scan task ${line}..."
+  cf terminate-task scanner-ui ${line}
+done
+
 # this tells cloud.gov to run the scan
 # XXX This is assuming that the output of getdomains won't change
 # XXX too much between when we run it here and when it runs on the

--- a/spawn_scans.sh
+++ b/spawn_scans.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# This script takes split domains provided by getdomains.sh and spawns
+# concurrent cloud.gov jobs for each.
+#
+
+TMPDIR="${TMPDIR:-/tmp}"
+./getdomains.sh "$TMPDIR/splitdir"
+
+# this tells cloud.gov to run the scan
+# XXX This is assuming that the output of getdomains won't change
+# XXX too much between when we run it here and when it runs on the
+# XXX task nodes.  Probably a safe assumption, but there might be
+# XXX a better way to do this.
+for i in $(ls "$TMPDIR/splitdir") ; do
+  cf run-task scanner-ui "/app/scan_engine.sh $i" --name "scan_engine $i" -m 512M -k 4096M
+  if [ "$?" != "0" ] ; then
+    echo "running task on $i failed to work, pausing until previous jobs complete"
+    NUMSCANS="$(cf tasks scanner-ui | grep RUNNING | wc -l)"
+    until [ "$(cf tasks scanner-ui | grep RUNNING | wc -l)" != "$NUMSCANS" ] ; do
+      echo "waiting until there's room to run $i"
+      sleep 600
+    done
+    cf run-task scanner-ui "/app/scan_engine.sh $i" --name "scan_engine $i" -m 512M -k 4096M
+    if [ "$?" != "0" ] ; then
+      FAILED="$i $FAILED"
+      echo "$i task failed twice:  maybe we are out of memory?  Investigate!"
+      echo "    trying the next task..."
+    fi
+  fi
+done
+if [ -n "$FAILED" ] ; then
+  echo "summary of tasks that failed:  $FAILED"
+  exit 1
+fi

--- a/spawn_scans.sh
+++ b/spawn_scans.sh
@@ -13,7 +13,7 @@ TMPDIR="${TMPDIR:-/tmp}"
 # XXX task nodes.  Probably a safe assumption, but there might be
 # XXX a better way to do this.
 for i in $(ls "$TMPDIR/splitdir") ; do
-  cf run-task scanner-ui "/app/scan_engine.sh $i" --name "scan_engine $i" -m 512M -k 4096M
+  cf run-task scanner-ui "/app/scan_engine.sh $i" --name "scan_engine $i" -m 1024M -k 4096M
   if [ "$?" != "0" ] ; then
     echo "running task on $i failed to work, pausing until previous jobs complete"
     NUMSCANS="$(cf tasks scanner-ui | grep RUNNING | wc -l)"
@@ -21,7 +21,7 @@ for i in $(ls "$TMPDIR/splitdir") ; do
       echo "waiting until there's room to run $i"
       sleep 600
     done
-    cf run-task scanner-ui "/app/scan_engine.sh $i" --name "scan_engine $i" -m 512M -k 4096M
+    cf run-task scanner-ui "/app/scan_engine.sh $i" --name "scan_engine $i" -m 1024M -k 4096M
     if [ "$?" != "0" ] ; then
       FAILED="$i $FAILED"
       echo "$i task failed twice:  maybe we are out of memory?  Investigate!"


### PR DESCRIPTION
* Move daily scan logic out of CircleCI config and into separate script
* Before starting daily scans, kill any scans from the previous day that are still running
* Increase gunicorn timeout to prevent large downloads from being killed mid-stream