### PR TITLE
Fix failing USWDS test.

### DIFF
--- a/scanner_ui/api/tests.py
+++ b/scanner_ui/api/tests.py
@@ -321,7 +321,7 @@ class CheckAPI(SimpleTestCase):
         url = '/api/v1/lists/uswds2/values/data.uswdsversion/'
         response = self.client.get(url)
         jsondata = json.loads(response.content)
-        self.assertIn('v2.6.0', jsondata)
+        self.assertTrue(any(s.startswith('v2') for s in jsondata))
 
     def test_subdomains_work(self):
         """test calendar.gsa.gov subdomain exists"""


### PR DESCRIPTION
Why: The exisiting USWDS test checks for a specific semantic version of
USWDS on the 18F website. This will cause this test to fail whenever the
18F website updates it's minor or patch version.

Instead, change this test to look at the major version (in this case v2)
and validate that the field exists.

How: Updating the scanner_ui/api/tests.

Tags: test, bugfix