### PR TITLE
Fix puppeteer spottiness. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.7
-        user: root
     steps:
     - checkout
     # Download and cache dependencies


### PR DESCRIPTION
Why: This seems to be the root cause of the Puppeteer issue. Removing
this for now.

How: removing root from the circle docker configuration file.

Tags: circleci, cicd, puppeteer