### PR TITLE
Add puppeteer-specific dependencies with apt.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,15 @@ COPY poetry.lock pyproject.toml ./
 # install runtime deps - uses $POETRY_VIRTUALENVS_IN_PROJECT internally
 RUN poetry install --no-dev
 
+
 # stage for running everything
 FROM python-base as production
 COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
 RUN mkdir /app
 WORKDIR /app
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+
+# dependencies for third-parties.js
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     awscli \
@@ -77,6 +80,16 @@ RUN apt-get update && \
     wget \
     xdg-utils
 COPY . /app/
+# get puppeteer-specific dependencies
+# https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 RUN npm install
 ENV LIGHTHOUSE_PATH /app/node_modules/lighthouse/lighthouse-cli/index.js
 ENV CHROME_PATH /usr/bin/chromium


### PR DESCRIPTION
See: [Puppeteer in Docker](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker)

Why: We are having a lot of spottiness with Puppeteer.

How: Adding dependencies through apt for puppeteer.

Tags: puppeteer