### PR TITLE
Remove Lighthouse for now. Increase batch size.

### DIFF
--- a/getdomains.sh
+++ b/getdomains.sh
@@ -5,7 +5,7 @@
 #
 
 # This is how many domains to scan in a single task
-BATCHSIZE="${BATCHSIZE:-3000}"
+BATCHSIZE="${BATCHSIZE:-6000}"
 
 BINDIR=$(dirname "$0")
 

--- a/scan_engine.sh
+++ b/scan_engine.sh
@@ -19,7 +19,6 @@ SCANTYPES="
 	dap
 	third_parties
 	pshtt
-	lighthouse
 "
 
 # This is where you set the repo/branch


### PR DESCRIPTION
**Why**: Lighthouse scans are consistently running until getting terminated
by the next day's jobs. We are going to turn them off for now.
Additionally, we are not able to run all of the tasks at once on the
cloud.gov instance. This is because the batch size of 3000 generates
nine tasks. Increase to 6000 which should generate five tasks.

**How**: Changing scan-engine.sh scans, and getdomains.sh batch size.

**Tags**: bugfix, scan-engine.