### PR TITLE
Add sitescan cloud.gov variables to CircleCI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,27 @@ jobs:
             cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
             cf install-plugin blue-green-deploy -r CF-Community -f
       - run:
-          name: deploy to cloud.gov
+          name: deploy to cloud.gov 10x
+          command: |
+            # If we do not specify a space, then deploy to the branch that we are on.
+            # This lets you have dev/staging/main branches that automatically go to the right place.
+            if [ -z "$CF_SPACE" ] ; then
+              export CF_SPACE="$CIRCLE_BRANCH"
+            fi
+            if [ -z "$CF_ORG" ] ; then
+              echo CF_ORG not set, aborting
+              exit 1
+            fi
+            cf api https://api.fr.cloud.gov
+            cf auth "$CF_USERNAME" "$CF_PASSWORD"
+            cf target -o "$CF_ORG" -s "$CF_SPACE"
+
+            # generate our requirements.txt file on the fly
+            poetry export -f requirements.txt --without-hashes > requirements.txt
+            ./deploy-cloudgov.sh zdt
+
+      - run:
+          name: deploy to cloud.gov sitescan
           command: |
             # If we do not specify a space, then deploy to the branch that we are on.
             # This lets you have dev/staging/main branches that automatically go to the right place.
@@ -76,7 +96,7 @@ jobs:
       - run:
           <<: *installcf
       - run:
-          name: run scan
+          name: run scan 10x
           no_output_timeout: 1h
           command: |
             # If we do not specify a space, then deploy to the branch that we are on.
@@ -91,6 +111,26 @@ jobs:
             cf api https://api.fr.cloud.gov
             cf auth "$CF_USERNAME" "$CF_PASSWORD"
             cf target -o "$CF_ORG" -s "$CF_SPACE"
+
+            poetry install
+            poetry run ./spawn_scans.sh
+
+      - run:
+          name: run scan sitescan
+          no_output_timeout: 1h
+          command: |
+            # If we do not specify a space, then deploy to the branch that we are on.
+            # This lets you have dev/staging/main branches that automatically go to the right place.
+            if [ -z "$SITESCAN_SPACE" ] ; then
+              export SITESCAN_SPACE="$CIRCLE_BRANCH"
+            fi
+            if [ -z "$SITESCAN_ORG" ] ; then
+              echo SITESCAN_ORG not set, aborting
+              exit 1
+            fi
+            cf api https://api.fr.cloud.gov
+            cf auth "$SITESCAN_USERNAME" "$SITESCAN_PASSWORD"
+            cf target -o "$SITESCAN_ORG" -s "$SITESCAN_SPACE"
 
             poetry install
             poetry run ./spawn_scans.sh


### PR DESCRIPTION
Why: In order to support both environments before the switch to the
sitescan cloud.gov environment.

How: Updating the circle ci config to have sitescan specific jobs.

Tags: circleci, migration