### PR TITLE
add GTM code, remove legacy DAP code

### DIFF
--- a/scanner_ui/ui/templates/base_generic.html
+++ b/scanner_ui/ui/templates/base_generic.html
@@ -8,9 +8,20 @@
   <!-- Add additional CSS in static file -->
   {% load static %}
   <link rel="stylesheet" type="text/css" href="{% static 'css/styles.css' %}">
-  <script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
+  
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-MNT5VXS');</script>
+  <!-- End Google Tag Manager --> 
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MNT5VXS"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <div class="container-fluid">
     <div class="row">
       <div class="col-sm-2">


### PR DESCRIPTION
This PR adds the Google Tag Manager (GTM) code to the Site Scanning website pages at https://site-scanning.app.cloud.gov/.

GTM code will then be able to add DAP and any other Google Analytics or other code to the site we feel is needed. 

Relates to issue #610 
